### PR TITLE
Move mouth animations into program space

### DIFF
--- a/libraries/Otto/Otto.cpp
+++ b/libraries/Otto/Otto.cpp
@@ -614,7 +614,7 @@ unsigned long int Otto::getMouthShape(int number){
 
 unsigned long int Otto::getAnimShape(int anim, int index){
 
-  unsigned long int littleUuh_code[]={
+  const static PROGMEM unsigned long int littleUuh_code[]={
      0b00000000000000001100001100000000,
      0b00000000000000000110000110000000,
      0b00000000000000000011000011000000,
@@ -625,14 +625,14 @@ unsigned long int Otto::getAnimShape(int anim, int index){
      0b00000000000000011000011000000000  
   };
 
-  unsigned long int dreamMouth_code[]={
+  const static PROGMEM unsigned long int dreamMouth_code[]={
      0b00000000000000000000110000110000,
      0b00000000000000010000101000010000,  
      0b00000000011000100100100100011000,
      0b00000000000000010000101000010000           
   };
 
-  unsigned long int adivinawi_code[]={
+  const static PROGMEM unsigned long int adivinawi_code[]={
      0b00100001000000000000000000100001,
      0b00010010100001000000100001010010,
      0b00001100010010100001010010001100,
@@ -641,7 +641,7 @@ unsigned long int Otto::getAnimShape(int anim, int index){
      0b00000000000000000000000000000000
   };
 
-  unsigned long int wave_code[]={
+  const static PROGMEM unsigned long int wave_code[]={
      0b00001100010010100001000000000000,
      0b00000110001001010000100000000000,
      0b00000011000100001000010000100000,
@@ -655,7 +655,7 @@ unsigned long int Otto::getAnimShape(int anim, int index){
   };
 
 
-  unsigned long int otto_code[]={
+  const static PROGMEM unsigned long int otto_code[]={
      0b00001100010010010010010010001100,
      0b00000000000000000000000000000000,
      0b00011100001000001000001000001000,
@@ -670,19 +670,19 @@ unsigned long int Otto::getAnimShape(int anim, int index){
   switch  (anim){
 
     case littleUuh:
-        return littleUuh_code[index];
+        return pgm_read_dword(&littleUuh_code[index]);
         break;
     case dreamMouth:
-        return dreamMouth_code[index];
+        return pgm_read_dword(&dreamMouth_code[index]);
         break;
     case adivinawi:
-        return adivinawi_code[index];
+        return pgm_read_dword(&adivinawi_code[index]);
         break;
     case wave:
-        return wave_code[index];
+        return pgm_read_dword(&wave_code[index]);
         break;
     case otto:
-        return otto_code[index];
+        return pgm_read_dword(&otto_code[index]);
         break;        
   }   
 }


### PR DESCRIPTION
I'm seeing memory problems on my Otto.
When compiling, Arduino IDE showed notice of 92% usage of dynamic memory.

This PR moves the mouth animations into program space, which translates in a 7% memory saving.